### PR TITLE
Disable voip 

### DIFF
--- a/src/components/structures/LoggedInView.tsx
+++ b/src/components/structures/LoggedInView.tsx
@@ -56,6 +56,8 @@ import { ToggleRightPanelPayload } from "../../dispatcher/payloads/ToggleRightPa
 import { IThreepidInvite } from "../../stores/ThreepidInviteStore";
 import { ICollapseConfig } from "../../resizer/distributors/collapse";
 import HostSignupContainer from '../views/host_signup/HostSignupContainer';
+import {UIFeature} from "../../settings/UIFeature";
+
 
 // We need to fetch each pinned message individually (if we don't already have it)
 // so each pinned message may trigger a request. Limit the number per room for sanity.
@@ -161,7 +163,9 @@ class LoggedInView extends React.Component<IProps, IState> {
         // stash the MatrixClient in case we log out before we are unmounted
         this._matrixClient = this.props.matrixClient;
 
-        CallMediaHandler.loadDevices();
+        if (SettingsStore.getValue(UIFeature.Voip)) {
+            CallMediaHandler.loadDevices();
+        }
 
         fixupColorFonts();
 

--- a/src/settings/Settings.ts
+++ b/src/settings/Settings.ts
@@ -683,7 +683,7 @@ export const SETTINGS: {[setting: string]: ISetting} = {
     },
     [UIFeature.Voip]: {
         supportedLevels: LEVELS_UI_FEATURE,
-        default: true,
+        default: false,
     },
     [UIFeature.Feedback]: {
         supportedLevels: LEVELS_UI_FEATURE,


### PR DESCRIPTION
Attempt to disable VOIP cleanly. 

With this PR, the setting UIFeature.Voip is "enabled" but its value is false by default.
(removing the settings makes other things crash)

This runs with matrix-js-sdk 12.0.1. 

In progress : Can we make this run with latest matrix-js-sdk ? 